### PR TITLE
Revert "hammerhead: Update overlay for PerformanceManager"

### DIFF
--- a/overlay/vendor/cmsdk/cm/res/res/values/config.xml
+++ b/overlay/vendor/cmsdk/cm/res/res/values/config.xml
@@ -19,10 +19,6 @@
 
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
 
-    <!-- Performance profiles -->
-    <string name="config_perf_profile_prop">powerhal</string>
-    <string name="config_perf_profile_default_entry">1</string>
-
     <!-- Default values for display color temperature -->
     <integer name="config_dayColorTemperature">6600</integer>
     <integer name="config_nightColorTemperature">5000</integer>


### PR DESCRIPTION
This reverts commit 1a80f6cdc4ddaaf98f1f3d878045e5e7002ef621.

Change-Id: I9af30c4934bad151755ca7a5b6b8e113a3095f01